### PR TITLE
Idiomatic fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,6 @@ type Options struct {
 	LogLevel    string        `desc:"log severity level" from:"env,flag"`
 }
 
-var
 func main() {
 	options = Options{
 		Timeout:     time.Second * 5,

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 # go-config
 
- Simpler Go configuration with structs.
+Simpler Go configuration with structs.
 
 ## Features
 
@@ -23,38 +23,38 @@ Source:
 package main
 
 import (
-  "log"
-  "os"
-  "time"
+	"log"
+	"os"
+	"time"
 
-  "github.com/tj/go-config"
+	"github.com/tj/go-config"
 )
 
 type Options struct {
-  Timeout     time.Duration `desc:"message timeout"`
-  Concurrency uint          `desc:"message concurrency"`
-  CacheSize   config.Bytes  `desc:"cache size in bytes"`
-  BatchSize   uint          `desc:"batch size" validate:"min=1,max=1000"`
-  LogLevel    string        `desc:"log severity level" from:"env,flag"`
+	Timeout     time.Duration `desc:"message timeout"`
+	Concurrency uint          `desc:"message concurrency"`
+	CacheSize   config.Bytes  `desc:"cache size in bytes"`
+	BatchSize   uint          `desc:"batch size" validate:"min=1,max=1000"`
+	LogLevel    string        `desc:"log severity level" from:"env,flag"`
 }
 
-var options = &Options{
-  Timeout:     time.Second * 5,
-  Concurrency: 10,
-  CacheSize:   config.ParseBytes("100mb"),
-  BatchSize:   250,
-}
-
+var
 func main() {
-  config.MustResolve(options)
-  log.Printf("%+v", options)
+	options = Options{
+		Timeout:     time.Second * 5,
+		Concurrency: 10,
+		CacheSize:   config.ParseBytes("100mb"),
+		BatchSize:   250,
+	}
+	config.MustResolve(&options)
+	log.Printf("%+v", options)
 }
 ```
 
 Command-line:
 
 ```
-$ LOG_LEVEL=error example --timeout 10s --concurrenct 100 --cache-size 1gb
+$ LOG_LEVEL=error example --timeout 10s --concurrency 100 --cache-size 1gb
 ```
 
 # License

--- a/config.go
+++ b/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -11,7 +11,7 @@ import (
 
 // Errors used during resolution.
 var (
-	ErrFieldNotFound = fmt.Errorf("field not found")
+	ErrFieldNotFound = errors.New("field not found")
 )
 
 // Config resolves options from the provided struct
@@ -30,15 +30,15 @@ type Config struct {
 // Resolve the configuration.
 func (c *Config) Resolve() error {
 	if c.Options == nil {
-		return fmt.Errorf("Config.Options required")
+		return errors.New("Config.Options required")
 	}
 
 	if len(c.Resolvers) == 0 {
-		return fmt.Errorf("Config.Resolvers required")
+		return errors.New("Config.Resolvers required")
 	}
 
 	if reflect.ValueOf(c.Options).Kind() != reflect.Ptr {
-		return fmt.Errorf("Config.Options must be a pointer")
+		return errors.New("Config.Options must be a pointer")
 	}
 
 	for _, resolver := range c.Resolvers {

--- a/config_test.go
+++ b/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfig_Resolve_validation(t *testing.T) {
+func TestConfigResolveValidation(t *testing.T) {
 	o := struct {
 		Concurrency int `name:"concurrency" desc:"some number" validate:"min=1,max=5"`
 	}{}
@@ -27,7 +27,7 @@ func TestConfig_Resolve_validation(t *testing.T) {
 	assert.EqualError(t, err, `Concurrency: less than min`)
 }
 
-func TestConfig_Resolve_default_name(t *testing.T) {
+func TestConfigResolveDefaultName(t *testing.T) {
 	o := struct {
 		MaxInFlight int
 	}{}
@@ -49,7 +49,7 @@ func TestConfig_Resolve_default_name(t *testing.T) {
 	assert.Equal(t, 5, o.MaxInFlight)
 }
 
-func TestConfig_Resolve_tag_name(t *testing.T) {
+func TestConfigResolveTagName(t *testing.T) {
 	o := struct {
 		MaxInFlight int `name:"concurrency"`
 	}{}
@@ -76,7 +76,7 @@ type Redis struct {
 	Port int
 }
 
-func TestConfig_Resolve_nested(t *testing.T) {
+func TestConfigResolveNested(t *testing.T) {
 	o := struct {
 		NSQ struct {
 			Messages struct {
@@ -120,7 +120,7 @@ type Bar struct {
 	Baz string
 }
 
-func TestConfig_Resolve_nested_pointers(t *testing.T) {
+func TestConfigResolveNestedPointers(t *testing.T) {
 	o := struct {
 		Foo *Foo
 	}{

--- a/env_resolver.go
+++ b/env_resolver.go
@@ -38,20 +38,20 @@ func (e *EnvResolver) Field(field Field) error {
 }
 
 // Resolve implementation (temporary noop).
-func (f *EnvResolver) Resolve() error {
+func (*EnvResolver) Resolve() error {
 	return nil
 }
 
 // Normalize `name` with prefix support.
-func (f *EnvResolver) envize(name string) string {
-	if f.Prefix != "" {
-		return f.normalize(f.Prefix) + "_" + f.normalize(name)
+func (e *EnvResolver) envize(name string) string {
+	if e.Prefix != "" {
+		return e.normalize(e.Prefix) + "_" + e.normalize(name)
 	}
 
-	return f.normalize(name)
+	return e.normalize(name)
 }
 
 // Normalize `name`.
-func (f *EnvResolver) normalize(name string) string {
+func (*EnvResolver) normalize(name string) string {
 	return strings.ToUpper(strings.Replace(name, "-", "_", -1))
 }

--- a/env_resolver_test.go
+++ b/env_resolver_test.go
@@ -48,7 +48,7 @@ func TestEnvResolver(t *testing.T) {
 	assert.Equal(t, []string{"0.0.0.0:3001", "0.0.0.0:3002"}, o.Addresses)
 }
 
-func TestEnvResolver_prefix(t *testing.T) {
+func TestEnvResolverPrefix(t *testing.T) {
 	o := struct {
 		Port    uint   `name:"port" desc:"redis port"`
 		Address string `name:"address" desc:"redis address"`

--- a/example_nested_test.go
+++ b/example_nested_test.go
@@ -19,7 +19,7 @@ type NestedOptions struct {
 // ExampleNested illustrates how nested structs may be used. In this
 // example --nsq-address and --nsq-max-in-flight flags would be
 // available, as well as NSQ_ADDRESS and NSQ_MAX_IN_FLIGHT.
-func Example_nested() {
+func ExampleNested() {
 	options := &NestedOptions{}
 
 	c := config.Config{

--- a/example_resolvers_test.go
+++ b/example_resolvers_test.go
@@ -18,7 +18,7 @@ type ResolverOptions struct {
 
 // ExampleResolvers illustrates how you may initialize a Config
 // struct in order to provide custom resolvers for more flexibility.
-func Example_resolvers() {
+func ExampleResolvers() {
 	options := &ResolverOptions{
 		Timeout:     5 * time.Second,
 		Concurrency: 5,

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ type Options struct {
 // ExampleResolve illustrates the simplest way to use go-config. Using
 // the MustResolve function pre-configures the flag and env resolvers for
 // the average use-case.
-func Example_resolve() {
+func ExampleResolve() {
 	options := &Options{
 		Concurrency: 5,
 		LogLevel:    "info",

--- a/sugar.go
+++ b/sugar.go
@@ -23,8 +23,7 @@ func Resolve(options interface{}) error {
 
 // MustResolve `options` using the built-in flag and env resolvers.
 func MustResolve(options interface{}) {
-	err := Resolve(options)
-	if err != nil {
+	if err := Resolve(options); err != nil {
 		log.Fatalf("error resolving configuration: %s", err)
 	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBoolValue_Set(t *testing.T) {
+func TestBoolValueSet(t *testing.T) {
 	{
 		v := boolValue(false)
 		err := v.Set("1")
@@ -50,7 +50,7 @@ func TestBoolValue_Set(t *testing.T) {
 	}
 }
 
-func TestIntValue_Set(t *testing.T) {
+func TestIntValueSet(t *testing.T) {
 	{
 		v := intValue(123)
 		err := v.Set("50")
@@ -65,7 +65,7 @@ func TestIntValue_Set(t *testing.T) {
 	}
 }
 
-func TestUintValue_Set(t *testing.T) {
+func TestUintValueSet(t *testing.T) {
 	{
 		v := uintValue(123)
 		err := v.Set("50")
@@ -80,7 +80,7 @@ func TestUintValue_Set(t *testing.T) {
 	}
 }
 
-func TestFloatValue_Set(t *testing.T) {
+func TestFloatValueSet(t *testing.T) {
 	{
 		v := floatValue(123)
 		err := v.Set("50.99")
@@ -95,7 +95,7 @@ func TestFloatValue_Set(t *testing.T) {
 	}
 }
 
-func TestStringValue_Set(t *testing.T) {
+func TestStringValueSet(t *testing.T) {
 	{
 		v := stringValue("something")
 		err := v.Set("hello")
@@ -104,7 +104,7 @@ func TestStringValue_Set(t *testing.T) {
 	}
 }
 
-func TestStringsValue_Set(t *testing.T) {
+func TestStringsValueSet(t *testing.T) {
 	{
 		v := stringsValue{}
 		assert.Nil(t, v.Set("hello"))


### PR DESCRIPTION
Primary change is removing globally-scoped config type in the README, which you should probably avoid if you can. [See here](https://robots.thoughtbot.com/where-to-define-command-line-flags-in-go) for additional rationalization.

Also, various fixes for vet and lint.